### PR TITLE
Initialize API key field w/ current clipboard contents

### DIFF
--- a/TicketMonitor/programPackage.Designer.cs
+++ b/TicketMonitor/programPackage.Designer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Windows.Forms;
 
 namespace TicketMonitor
 {
@@ -66,6 +67,7 @@ namespace TicketMonitor
             this.apiKeyField.PasswordChar = '*';
             this.apiKeyField.Size = new System.Drawing.Size(225, 20);
             this.apiKeyField.TabIndex = 2;
+            this.apiKeyField.Paste(Clipboard.GetText());
             // 
             // usernameLabel
             // 


### PR DESCRIPTION
Boy oh boy I've never made a pull request before. Anyway, this feature may be a workaround to not being able to paste: on creation, the API key field will contain your clipboard's contents. Saves a couple clicks for everyone else, too.